### PR TITLE
chore(Root): enforce npm package contract in CI

### DIFF
--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -27,4 +27,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
+    - run: npm run tsc
+    - run: npm run cpdir
+    - run: npm run verify:package-contract
     - run: npm test

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A tiny simple front-end library for building web applications",
   "main": "dist/index.js",
   "type": "module",
+  "engines": {
+    "node": ">=18 <21"
+  },
   "exports": {
     ".": "./dist/index.js",
     "./server": "./dist/server.js"
@@ -17,8 +20,9 @@
   "scripts": {
     "tsc": "tsc -p tsconfig.json",
     "cpdir": "cp -r ./src/ssr ./dist/",
-    "co:build": "npm run tsc && npm run cpdir && vitest run && npm run lint",
-    "build": "npm run tsc && npm run cpdir && npm run coverage && npm run lint",
+    "verify:package-contract": "node scripts/verify-package-contract.cjs",
+    "co:build": "npm run tsc && npm run cpdir && npm run verify:package-contract && vitest run && npm run lint",
+    "build": "npm run tsc && npm run cpdir && npm run verify:package-contract && npm run coverage && npm run lint",
     "co": "npm run co:build && git add . && sui-mono commit && git push",
     "check": "node scripts/check.cjs",
     "release": "node scripts/release.cjs",

--- a/scripts/verify-package-contract.cjs
+++ b/scripts/verify-package-contract.cjs
@@ -1,0 +1,105 @@
+/* eslint no-console:0 */
+
+const fs = require('fs')
+const path = require('path')
+const {execSync} = require('child_process')
+
+const ROOT = process.cwd()
+const PACKAGE_JSON_PATH = path.join(ROOT, 'package.json')
+
+const fail = message => {
+  console.error(`[package-contract] ${message}`)
+  process.exit(1)
+}
+
+const ensureFileExists = (relativePath, label) => {
+  const fullPath = path.join(ROOT, relativePath)
+  if (!fs.existsSync(fullPath)) {
+    fail(`${label} does not exist: ${relativePath}`)
+  }
+}
+
+const toPackPath = relativePath => relativePath.replace(/^\.\//, '')
+
+const readPackageJson = () => JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf8'))
+
+const normalizeExportTarget = target => {
+  if (typeof target === 'string') return [target]
+  if (!target || typeof target !== 'object') return []
+
+  const values = []
+  for (const value of Object.values(target)) {
+    values.push(...normalizeExportTarget(value))
+  }
+  return values
+}
+
+const getPackedFiles = () => {
+  const output = execSync('npm pack --json --dry-run', {encoding: 'utf8'})
+  const parsed = JSON.parse(output)
+  const packInfo = Array.isArray(parsed) ? parsed[0] : parsed
+
+  if (!packInfo || !Array.isArray(packInfo.files)) {
+    fail('Could not inspect npm pack output')
+  }
+
+  return new Set(packInfo.files.map(file => file.path))
+}
+
+const main = () => {
+  const pkg = readPackageJson()
+
+  if (!pkg.exports || typeof pkg.exports !== 'object') {
+    fail('package.json must define an exports map')
+  }
+
+  if (!Array.isArray(pkg.files) || !pkg.files.includes('dist/')) {
+    fail('package.json files must include dist/')
+  }
+
+  if (!pkg.main || !pkg.main.startsWith('dist/')) {
+    fail('package.json main must point to dist/')
+  }
+
+  ensureFileExists(pkg.main, 'main entrypoint')
+
+  const exportTargets = normalizeExportTarget(pkg.exports)
+  if (exportTargets.length === 0) {
+    fail('No export targets found in package.json exports')
+  }
+
+  exportTargets.forEach(target => {
+    if (!target.startsWith('./dist/')) {
+      fail(`Export target must point to ./dist/: ${target}`)
+    }
+    ensureFileExists(target, 'export target')
+  })
+
+  const packedFiles = getPackedFiles()
+
+  exportTargets.forEach(target => {
+    const packPath = toPackPath(target)
+    if (!packedFiles.has(packPath)) {
+      fail(`Export target missing from npm package: ${packPath}`)
+    }
+  })
+
+  const mainPackPath = toPackPath(`./${pkg.main}`)
+  if (!packedFiles.has(mainPackPath)) {
+    fail(`Main entrypoint missing from npm package: ${mainPackPath}`)
+  }
+
+  const hasSourceLeak = [...packedFiles].some(file => file.startsWith('src/'))
+  if (hasSourceLeak) {
+    fail('npm package should not include source files under src/')
+  }
+
+  const hasTestLeak = [...packedFiles].some(file => file.startsWith('test/'))
+  if (hasTestLeak) {
+    fail('npm package should not include tests under test/')
+  }
+
+  console.log('[package-contract] OK: exports/files/dist contract is valid')
+}
+
+main()


### PR DESCRIPTION
## Summary
Add a package publication contract gate to prevent regressions in npm artifacts.

### Included changes
- Add package contract verifier script for exports/files/dist and packed artifact checks.
- Add verify:package-contract script in package.json.
- Run the package-contract verification in co:build and build.
- Run package-contract verification in CI workflow.
- Define Node runtime baseline with engines.node.

## Why
This blocks accidental release of broken public entrypoints or invalid package contents.

## Validation
- node scripts/verify-package-contract.cjs passes.
- npm pack --json --dry-run output is inspected and validated.

## Dependency
This PR is created from main as requested and is expected to be merged after #46.
