### PR TITLE
feat(Root): implement TreeWalker whatToShow/filter support for SSR

### DIFF
--- a/dist/ssr/register/dom/Document.js
+++ b/dist/ssr/register/dom/Document.js
@@ -8,6 +8,49 @@ const { find, nodeName } = require('../util')
 
 const createElement = document.createElement.bind(document)
 
+function getWhatToShowForNode(node) {
+  if (!node) return 0
+  if (node.nodeName === '#document') return NodeFilter.SHOW_DOCUMENT
+
+  switch (node.nodeType) {
+  case Node.COMMENT_NODE:
+    return NodeFilter.SHOW_COMMENT
+  case Node.DOCUMENT_FRAGMENT_NODE:
+    return NodeFilter.SHOW_DOCUMENT_FRAGMENT
+  case Node.ELEMENT_NODE:
+    return NodeFilter.SHOW_ELEMENT
+  case Node.TEXT_NODE:
+    return NodeFilter.SHOW_TEXT
+  default:
+    return 0
+  }
+}
+
+function shouldShowNode(node, whatToShow) {
+  if (whatToShow == null || whatToShow === NodeFilter.SHOW_ALL) {
+    return true
+  }
+
+  const nodeFlag = getWhatToShowForNode(node)
+  return nodeFlag !== 0 && (whatToShow & nodeFlag) !== 0
+}
+
+function applyNodeFilter(node, filter) {
+  if (!filter) {
+    return NodeFilter.FILTER_ACCEPT
+  }
+
+  if (typeof filter === 'function') {
+    return filter(node)
+  }
+
+  if (typeof filter.acceptNode === 'function') {
+    return filter.acceptNode(node)
+  }
+
+  return NodeFilter.FILTER_ACCEPT
+}
+
 class Document extends Element {
   constructor() {
     super()
@@ -54,9 +97,7 @@ class Document extends Element {
 
   createTreeWalker(
     root,
-    // TODO needs implemeting.
     whatToShow = NodeFilter.SHOW_ALL,
-    // TODO needs implemeting.
     filter = { acceptNode: () => NodeFilter.FILTER_ACCEPT }
   ) {
     // Use an array so we don't have to use recursion.
@@ -64,13 +105,24 @@ class Document extends Element {
     return {
       currentNode: null,
       nextNode() {
-        this.currentNode = stack.shift()
-        if (this.currentNode) {
-          // We do this in *document order*, so descendents of earlier parents
-          // need to get visited first.
-          stack.unshift(...this.currentNode.childNodes)
+        while (stack.length) {
+          const next = stack.shift()
+          const result = applyNodeFilter(next, filter)
+
+          if (result !== NodeFilter.FILTER_REJECT) {
+            // We do this in *document order*, so descendents of earlier parents
+            // need to get visited first.
+            stack.unshift(...next.childNodes)
+          }
+
+          if (result === NodeFilter.FILTER_ACCEPT && shouldShowNode(next, whatToShow)) {
+            this.currentNode = next
+            return this.currentNode
+          }
         }
-        return this.currentNode || null
+
+        this.currentNode = null
+        return null
       }
     }
   }

--- a/src/ssr/register/dom/Document.js
+++ b/src/ssr/register/dom/Document.js
@@ -8,6 +8,49 @@ const { find, nodeName } = require('../util')
 
 const createElement = document.createElement.bind(document)
 
+function getWhatToShowForNode(node) {
+  if (!node) return 0
+  if (node.nodeName === '#document') return NodeFilter.SHOW_DOCUMENT
+
+  switch (node.nodeType) {
+  case Node.COMMENT_NODE:
+    return NodeFilter.SHOW_COMMENT
+  case Node.DOCUMENT_FRAGMENT_NODE:
+    return NodeFilter.SHOW_DOCUMENT_FRAGMENT
+  case Node.ELEMENT_NODE:
+    return NodeFilter.SHOW_ELEMENT
+  case Node.TEXT_NODE:
+    return NodeFilter.SHOW_TEXT
+  default:
+    return 0
+  }
+}
+
+function shouldShowNode(node, whatToShow) {
+  if (whatToShow == null || whatToShow === NodeFilter.SHOW_ALL) {
+    return true
+  }
+
+  const nodeFlag = getWhatToShowForNode(node)
+  return nodeFlag !== 0 && (whatToShow & nodeFlag) !== 0
+}
+
+function applyNodeFilter(node, filter) {
+  if (!filter) {
+    return NodeFilter.FILTER_ACCEPT
+  }
+
+  if (typeof filter === 'function') {
+    return filter(node)
+  }
+
+  if (typeof filter.acceptNode === 'function') {
+    return filter.acceptNode(node)
+  }
+
+  return NodeFilter.FILTER_ACCEPT
+}
+
 class Document extends Element {
   constructor() {
     super()
@@ -54,9 +97,7 @@ class Document extends Element {
 
   createTreeWalker(
     root,
-    // TODO needs implemeting.
     whatToShow = NodeFilter.SHOW_ALL,
-    // TODO needs implemeting.
     filter = { acceptNode: () => NodeFilter.FILTER_ACCEPT }
   ) {
     // Use an array so we don't have to use recursion.
@@ -64,13 +105,24 @@ class Document extends Element {
     return {
       currentNode: null,
       nextNode() {
-        this.currentNode = stack.shift()
-        if (this.currentNode) {
-          // We do this in *document order*, so descendents of earlier parents
-          // need to get visited first.
-          stack.unshift(...this.currentNode.childNodes)
+        while (stack.length) {
+          const next = stack.shift()
+          const result = applyNodeFilter(next, filter)
+
+          if (result !== NodeFilter.FILTER_REJECT) {
+            // We do this in *document order*, so descendents of earlier parents
+            // need to get visited first.
+            stack.unshift(...next.childNodes)
+          }
+
+          if (result === NodeFilter.FILTER_ACCEPT && shouldShowNode(next, whatToShow)) {
+            this.currentNode = next
+            return this.currentNode
+          }
         }
-        return this.currentNode || null
+
+        this.currentNode = null
+        return null
       }
     }
   }

--- a/test/ssr/register/Document.test.ts
+++ b/test/ssr/register/Document.test.ts
@@ -32,6 +32,46 @@ test('createTreeWalker', () => {
   ])
 })
 
+test('createTreeWalker supports whatToShow', () => {
+  document.head.innerHTML = '<div id="one">head text</div>'
+  document.body.innerHTML = '<div id="two">body text</div>'
+
+  const list = []
+  const tree = document.createTreeWalker(document, NodeFilter.SHOW_TEXT)
+
+  while (tree.nextNode()) {
+    list.push(tree.currentNode.nodeName)
+  }
+
+  expect(list).toMatchObject(['#text', '#text'])
+})
+
+test('createTreeWalker supports filter acceptNode', () => {
+  document.head.innerHTML = '<div id="one"><span class="skip-me">a</span></div>'
+  document.body.innerHTML = '<div id="two"><span class="reject-me">b</span></div>'
+
+  const list = []
+  const tree = document.createTreeWalker(document, NodeFilter.SHOW_ELEMENT, {
+    acceptNode(node) {
+      if (node.classList?.contains('skip-me')) {
+        return NodeFilter.FILTER_SKIP
+      }
+
+      if (node.classList?.contains('reject-me')) {
+        return NodeFilter.FILTER_REJECT
+      }
+
+      return NodeFilter.FILTER_ACCEPT
+    }
+  })
+
+  while (tree.nextNode()) {
+    list.push(tree.currentNode.nodeName)
+  }
+
+  expect(list).toMatchObject(['HTML', 'HEAD', 'DIV', 'BODY', 'DIV'])
+})
+
 describe('getElementById', () => {
   it('returns no elements on empty', () => {
     expect(document.getElementById('one')).toBe(null)

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vitest } from 'vitest'
-import { restoreGlobalThis } from './testing.ts'
 import { processGenerator, parseCSS, createInlineStyle, capitalizeFirstLetter, uncapitalizeFirstLetter, Emmy, loadGlobalEmmy, html, javascript, isServer } from '../src/utils.ts'
 
 describe('processGenerator', () => {
@@ -79,13 +78,24 @@ describe('javascript', () => {
 })
 
 const mockClient = () => {
-  const navigator = globalThis.navigator
-  const hasOwnProperty = globalThis.hasOwnProperty
-  const navigatorMock = { ...navigator, userAgent: 'Mozilla/5.0' }
-  const hasOwnPropertyMock = vitest.fn(() => false)
-  globalThis.navigator = navigatorMock
-  globalThis.hasOwnProperty = hasOwnPropertyMock
-  return { navigator, hasOwnProperty }
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    value: { userAgent: 'Mozilla/5.0' }
+  })
+
+  const hasOwnPropertySpy = vitest.spyOn(globalThis, 'hasOwnProperty').mockImplementation(() => false)
+
+  return () => {
+    hasOwnPropertySpy.mockRestore()
+
+    if (navigatorDescriptor) {
+      Object.defineProperty(globalThis, 'navigator', navigatorDescriptor)
+    }
+    else {
+      delete (globalThis as { navigator?: Navigator }).navigator
+    }
+  }
 }
 
 describe('isServer', () => {
@@ -93,8 +103,12 @@ describe('isServer', () => {
     expect(isServer()).toBe(true)
   })
   it('should return false if the code is running on the client', () => {
-    const { navigator, hasOwnProperty } = mockClient()
-    expect(isServer()).toBe(false)
-    restoreGlobalThis({ navigator, hasOwnProperty })
+    const restoreClient = mockClient()
+    try {
+      expect(isServer()).toBe(false)
+    }
+    finally {
+      restoreClient()
+    }
   })
 })


### PR DESCRIPTION
## Summary
Implement the first SSR core roadmap step by adding TreeWalker filtering support.

### Included changes
- Implement `Document#createTreeWalker(root, whatToShow, filter)` support for:
  - `whatToShow` bitmask filtering (SHOW_ELEMENT, SHOW_TEXT, SHOW_DOCUMENT, etc.).
  - `filter.acceptNode(node)` handling with `FILTER_ACCEPT`, `FILTER_SKIP`, and `FILTER_REJECT`.
- Preserve document-order traversal while honoring filter semantics.
- Add SSR tests for:
  - `whatToShow` behavior.
  - filter accept/skip/reject behavior.
- Harden `test/utils.test.ts` client mock cleanup for environments where `navigator` can be readonly/missing (keeps CI green while branches merge).

## Why
This unblocks the SSR P0 roadmap and removes TODO-level behavior in TreeWalker traversal.

## Validation
- `npx vitest run test/ssr/register/Document.test.ts test/utils.test.ts`
- `npm run co:build`
